### PR TITLE
replace RDF impl, remove LIT references

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,16 @@
 
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 0.5.3
+
+### Internal refactor
+
+- Replaced `@rdfjs/data-model` with `rdf-data-factory` (as it provides full
+TypeScript compatibility with the RDF/JS DataFactory type).
+- Only require RDF/JS implementation as a Dev dependency as opposed to a full
+dependency (meaning users of this library are completely free to depend on
+whatever implementation they choose).
+
 ## 0.5.2
 
 ### Patches

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ The Vocab Term objects from this library are intended to be simple wrappers
 around 'NamedNode' objects conforming to the [RDFJS interface](http://rdf.js.org/data-model-spec/).
 This means that Vocab Term instances can be used natively with libraries that
 are RDFJS-compliant, such as `rdf-ext` or `rdflib.js`. A `VocabTerm` may be
-built by passing an RDFJS `Datafactory` implemented with any library, but it also
-embeds a basic `Datafactory` implementation for simplicity.
+built by passing an RDFJS `DataFactory` implemented with any library, but it also
+embeds a basic `DataFactory` implementation for simplicity.
 
 ### Introductory example
 
@@ -63,7 +63,7 @@ We could represent this as a Vocab Term in JavaScript like so:
 ```javascript
 const {VocabTerm, buildStore} = require('@inrupt/solid-common-vocab')
 // Any other implementation of the RDFJS interfaces would also be appropriate.
-const rdf = require('rdf-ext')
+const rdf = require('rdfFactory-ext')
 
 // The third argument provides as a context - it will commonly store things like the current
 // language preference of the user, which can be used to lookup term labels or comments
@@ -100,7 +100,7 @@ const personLabelAsString = person.label.value
 const personCommentAsString = person.comment.value
 ```
 
-To use the emmbedded `Datafactory` implementation to build a VocabTerm, the 
+To use the emmbedded `DataFactory` implementation to build a VocabTerm, the 
 previous example would become: 
 
 ```javascript

--- a/demo/index.js
+++ b/demo/index.js
@@ -1,7 +1,7 @@
-const {LitVocabTermRdfExt:LitVocabTerm} = require('@pmcb55/lit-vocab-term-rdf-ext')
+const { VocabTerm } = require('@inrupt/solid-common-vocab')
 require('mock-local-storage')
 
-const person = new LitVocabTerm('https://example.com#Person', localStorage, true)
+const person = new VocabTerm('https://example.com#Person', localStorage, true)
   .addLabel('Person','en')
   .addLabel('Personne','fr')
   .addLabel('人', 'ch')

--- a/package-lock.json
+++ b/package-lock.json
@@ -465,6 +465,12 @@
             "json-schema-traverse": "^0.4.1",
             "uri-js": "^4.2.2"
           }
+        },
+        "ignore": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+          "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+          "dev": true
         }
       }
     },
@@ -961,14 +967,6 @@
         "fastq": "^1.6.0"
       }
     },
-    "@rdfjs/data-model": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@rdfjs/data-model/-/data-model-1.2.0.tgz",
-      "integrity": "sha512-6ITWcu2sr9zJqXUPDm1XJ8DRpea7PotWBIkTzuO1MCSruLOWH2ICoQOAtlJy30cT+GqH9oAQKPR+CHXejsdizA==",
-      "requires": {
-        "@types/rdf-js": "*"
-      }
-    },
     "@rollup/plugin-commonjs": {
       "version": "17.0.0",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-17.0.0.tgz",
@@ -993,9 +991,9 @@
       }
     },
     "@rollup/plugin-node-resolve": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-11.0.0.tgz",
-      "integrity": "sha512-8Hrmwjn1pLYjUxcv7U7IPP0qfnzEJWHyHE6CaZ8jbLM+8axaarJRB1jB6JgKTDp5gNga+TpsgX6F8iuvgOerKQ==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-11.0.1.tgz",
+      "integrity": "sha512-ltlsj/4Bhwwhb+Nb5xCz/6vieuEj2/BAkkqVIKmZwC7pIdl8srmgmglE4S0jFlZa32K4qvdQ6NHdmpRKD/LwoQ==",
       "dev": true,
       "requires": {
         "@rollup/pluginutils": "^3.1.0",
@@ -1101,12 +1099,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
-      "dev": true
-    },
-    "@types/eslint-visitor-keys": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
-      "integrity": "sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==",
       "dev": true
     },
     "@types/estree": {
@@ -1232,13 +1224,13 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.0.0.tgz",
-      "integrity": "sha512-5e6q1TR7gS2P+8W2xndCu7gBh3BzmYEo70OyIdsmCmknHha/yNbz2vdevl+tP1uoaMOcrzg4gyrAijuV3DDBHA==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.10.0.tgz",
+      "integrity": "sha512-h6/V46o6aXpKRlarP1AiJEXuCJ7cMQdlpfMDrcllIgX3dFkLwEBTXAoNP98ZoOmqd1xvymMVRAI4e7yVvlzWEg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "4.0.0",
-        "@typescript-eslint/scope-manager": "4.0.0",
+        "@typescript-eslint/experimental-utils": "4.10.0",
+        "@typescript-eslint/scope-manager": "4.10.0",
         "debug": "^4.1.1",
         "functional-red-black-tree": "^1.0.1",
         "regexpp": "^3.0.0",
@@ -1247,102 +1239,55 @@
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.0.0.tgz",
-      "integrity": "sha512-hbX6zR+a/vcpFVNJYN/Nbd7gmaMosDTxHEKcvmhWeWcq/0UDifrqmCfkkodbAKL46Fn4ekSBMTyq2zlNDzcQxw==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.10.0.tgz",
+      "integrity": "sha512-opX+7ai1sdWBOIoBgpVJrH5e89ra1KoLrJTz0UtWAa4IekkKmqDosk5r6xqRaNJfCXEfteW4HXQAwMdx+jjEmw==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/scope-manager": "4.0.0",
-        "@typescript-eslint/types": "4.0.0",
-        "@typescript-eslint/typescript-estree": "4.0.0",
+        "@typescript-eslint/scope-manager": "4.10.0",
+        "@typescript-eslint/types": "4.10.0",
+        "@typescript-eslint/typescript-estree": "4.10.0",
         "eslint-scope": "^5.0.0",
         "eslint-utils": "^2.0.0"
       }
     },
     "@typescript-eslint/parser": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-3.10.1.tgz",
-      "integrity": "sha512-Ug1RcWcrJP02hmtaXVS3axPPTTPnZjupqhgj+NnZ6BCkwSImWk/283347+x9wN+lqOdK9Eo3vsyiyDHgsmiEJw==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.10.0.tgz",
+      "integrity": "sha512-amBvUUGBMadzCW6c/qaZmfr3t9PyevcSWw7hY2FuevdZVp5QPw/K76VSQ5Sw3BxlgYCHZcK6DjIhSZK0PQNsQg==",
       "dev": true,
       "requires": {
-        "@types/eslint-visitor-keys": "^1.0.0",
-        "@typescript-eslint/experimental-utils": "3.10.1",
-        "@typescript-eslint/types": "3.10.1",
-        "@typescript-eslint/typescript-estree": "3.10.1",
-        "eslint-visitor-keys": "^1.1.0"
-      },
-      "dependencies": {
-        "@typescript-eslint/experimental-utils": {
-          "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-3.10.1.tgz",
-          "integrity": "sha512-DewqIgscDzmAfd5nOGe4zm6Bl7PKtMG2Ad0KG8CUZAHlXfAKTF9Ol5PXhiMh39yRL2ChRH1cuuUGOcVyyrhQIw==",
-          "dev": true,
-          "requires": {
-            "@types/json-schema": "^7.0.3",
-            "@typescript-eslint/types": "3.10.1",
-            "@typescript-eslint/typescript-estree": "3.10.1",
-            "eslint-scope": "^5.0.0",
-            "eslint-utils": "^2.0.0"
-          }
-        },
-        "@typescript-eslint/types": {
-          "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-3.10.1.tgz",
-          "integrity": "sha512-+3+FCUJIahE9q0lDi1WleYzjCwJs5hIsbugIgnbB+dSCYUxl8L6PwmsyOPFZde2hc1DlTo/xnkOgiTLSyAbHiQ==",
-          "dev": true
-        },
-        "@typescript-eslint/typescript-estree": {
-          "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-3.10.1.tgz",
-          "integrity": "sha512-QbcXOuq6WYvnB3XPsZpIwztBoquEYLXh2MtwVU+kO8jgYCiv4G5xrSP/1wg4tkvrEE+esZVquIPX/dxPlePk1w==",
-          "dev": true,
-          "requires": {
-            "@typescript-eslint/types": "3.10.1",
-            "@typescript-eslint/visitor-keys": "3.10.1",
-            "debug": "^4.1.1",
-            "glob": "^7.1.6",
-            "is-glob": "^4.0.1",
-            "lodash": "^4.17.15",
-            "semver": "^7.3.2",
-            "tsutils": "^3.17.1"
-          }
-        },
-        "@typescript-eslint/visitor-keys": {
-          "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-3.10.1.tgz",
-          "integrity": "sha512-9JgC82AaQeglebjZMgYR5wgmfUdUc+EitGUUMW8u2nDckaeimzW+VsoLV6FoimPv2id3VQzfjwBxEMVz08ameQ==",
-          "dev": true,
-          "requires": {
-            "eslint-visitor-keys": "^1.1.0"
-          }
-        }
+        "@typescript-eslint/scope-manager": "4.10.0",
+        "@typescript-eslint/types": "4.10.0",
+        "@typescript-eslint/typescript-estree": "4.10.0",
+        "debug": "^4.1.1"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.0.0.tgz",
-      "integrity": "sha512-9gcWUPoWo7gk/+ZQPg7L1ySRmR5HLIy3Vu6/LfhQbuzIkGm6v2CGIjpVRISoDLFRovNRDImd4aP/sa8O4yIEBg==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.10.0.tgz",
+      "integrity": "sha512-WAPVw35P+fcnOa8DEic0tQUhoJJsgt+g6DEcz257G7vHFMwmag58EfowdVbiNcdfcV27EFR0tUBVXkDoIvfisQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.0.0",
-        "@typescript-eslint/visitor-keys": "4.0.0"
+        "@typescript-eslint/types": "4.10.0",
+        "@typescript-eslint/visitor-keys": "4.10.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.0.0.tgz",
-      "integrity": "sha512-bK+c2VLzznX2fUWLK6pFDv3cXGTp7nHIuBMq1B9klA+QCsqLHOOqe5TQReAQDl7DN2RfH+neweo0oC5hYlG7Rg==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.10.0.tgz",
+      "integrity": "sha512-+dt5w1+Lqyd7wIPMa4XhJxUuE8+YF+vxQ6zxHyhLGHJjHiunPf0wSV8LtQwkpmAsRi1lEOoOIR30FG5S2HS33g==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.0.0.tgz",
-      "integrity": "sha512-ewFMPi2pMLDNIXGMPdf8r7El2oPSZw9PEYB0j+WcpKd7AX2ARmajGa7RUHTukllWX2bj4vWX6JLE1Oih2BMokA==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.10.0.tgz",
+      "integrity": "sha512-mGK0YRp9TOk6ZqZ98F++bW6X5kMTzCRROJkGXH62d2azhghmq+1LNLylkGe6uGUOQzD452NOAEth5VAF6PDo5g==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.0.0",
-        "@typescript-eslint/visitor-keys": "4.0.0",
+        "@typescript-eslint/types": "4.10.0",
+        "@typescript-eslint/visitor-keys": "4.10.0",
         "debug": "^4.1.1",
         "globby": "^11.0.1",
         "is-glob": "^4.0.1",
@@ -1352,12 +1297,12 @@
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.0.0.tgz",
-      "integrity": "sha512-sTouJbv6rjVJeTE4lpSBVYXq/u5K3gbB6LKt7ccFEZPTZB/VeQ0ssUz9q5Hx++sCqBbdF8PzrrgvEnicXAR6NQ==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.10.0.tgz",
+      "integrity": "sha512-hPyz5qmDMuZWFtHZkjcCpkAKHX8vdu1G3YsCLEd25ryZgnJfj6FQuJ5/O7R+dB1ueszilJmAFMtlU4CA6se3Jg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.0.0",
+        "@typescript-eslint/types": "4.10.0",
         "eslint-visitor-keys": "^2.0.0"
       },
       "dependencies": {
@@ -2011,9 +1956,9 @@
       }
     },
     "commander": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.0.tgz",
-      "integrity": "sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
       "dev": true
     },
     "commondir": {
@@ -2542,6 +2487,12 @@
               "dev": true
             }
           }
+        },
+        "ignore": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+          "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+          "dev": true
         }
       }
     },
@@ -3045,9 +2996,9 @@
       "dev": true
     },
     "fastq": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.8.0.tgz",
-      "integrity": "sha512-SMIZoZdLh/fgofivvIkmknUXyPnvxRE3DhtZ5Me3Mrsk5gyPL42F0xr51TdRXskBxHfMp+07bcYzfsYEsSQA9Q==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.9.0.tgz",
+      "integrity": "sha512-i7FVWL8HhVY+CTkwFxkN2mk3h+787ixS5S63eb78diVRc1MCssarHq3W5cj0av7YDSwmaV928RNag+U1etRQ7w==",
       "dev": true,
       "requires": {
         "reusify": "^1.0.4"
@@ -3354,14 +3305,6 @@
         "ignore": "^5.1.4",
         "merge2": "^1.3.0",
         "slash": "^3.0.0"
-      },
-      "dependencies": {
-        "ignore": {
-          "version": "5.1.8",
-          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
-          "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
-          "dev": true
-        }
       }
     },
     "graceful-fs": {
@@ -3592,15 +3535,15 @@
       }
     },
     "ignore": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+      "version": "5.1.8",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+      "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
       "dev": true
     },
     "import-fresh": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
-      "integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.2.tgz",
+      "integrity": "sha512-cTPNrlvJT6twpYy+YmKUKrTSjWFs3bjYjAhCwm+z4EOCubZxAuO+hHpRN64TqjEaYSHs7tJAE0w1CKMGmsG/lw==",
       "dev": true,
       "requires": {
         "parent-module": "^1.0.0",
@@ -6354,6 +6297,15 @@
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "dev": true
     },
+    "rdf-data-factory": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.0.4.tgz",
+      "integrity": "sha512-ZIIwEkLcV7cTc+atvQFzAETFVRHz1BRe/MhdkZqYse8vxskErj8/bF/Ittc3B5c0GTyw6O3jVF2V7xBRGyRoSQ==",
+      "dev": true,
+      "requires": {
+        "@types/rdf-js": "*"
+      }
+    },
     "react-is": {
       "version": "17.0.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.1.tgz",
@@ -6629,9 +6581,9 @@
       }
     },
     "rollup": {
-      "version": "2.34.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.34.2.tgz",
-      "integrity": "sha512-mvtQLqu3cNeoctS+kZ09iOPxrc1P1/Bt1z15enuQ5feyKOdM3MJAVFjjsygurDpSWn530xB4AlA83TWIzRstXA==",
+      "version": "2.35.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.35.1.tgz",
+      "integrity": "sha512-q5KxEyWpprAIcainhVy6HfRttD9kutQpHbeqDTWnqAFNJotiojetK6uqmcydNMymBEtC4I8bCYR+J3mTMqeaUA==",
       "dev": true,
       "requires": {
         "fsevents": "~2.1.2"
@@ -6665,9 +6617,9 @@
       "dev": true
     },
     "run-parallel": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
-      "integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==",
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.10.tgz",
+      "integrity": "sha512-zb/1OuZ6flOlH6tQyMPUrE3x3Ulxjlo9WIVXR4yVYi4H9UXQaeIsPbLn2R3O3vQCnDKkAl2qHiuocKKX4Tz/Sw==",
       "dev": true
     },
     "rxjs": {
@@ -7703,9 +7655,9 @@
       }
     },
     "typescript": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.2.tgz",
-      "integrity": "sha512-thGloWsGH3SOxv1SoY7QojKi0tc+8FnOmiarEGMbd/lar7QOEd3hvlx3Fp5y6FlDUGl9L+pd4n2e+oToGMmhRQ==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
+      "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
       "dev": true
     },
     "union-value": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "check-licenses": "license-checker --production --failOn \"AGPL-1.0-only; AGPL-1.0-or-later; AGPL-3.0-only; AGPL-3.0-or-later; Beerware; CC-BY-NC-1.0; CC-BY-NC-2.0; CC-BY-NC-2.5; CC-BY-NC-3.0; CC-BY-NC-4.0; CC-BY-NC-ND-1.0; CC-BY-NC-ND-2.0; CC-BY-NC-ND-2.5; CC-BY-NC-ND-3.0; CC-BY-NC-ND-4.0; CC-BY-NC-SA-1.0; CC-BY-NC-SA-2.0; CC-BY-NC-SA-2.5; CC-BY-NC-SA-3.0; CC-BY-NC-SA-4.0; CPAL-1.0; EUPL-1.0; EUPL-1.1; EUPL-1.1;  GPL-1.0-only; GPL-1.0-or-later; GPL-2.0-only;  GPL-2.0-or-later; GPL-3.0; GPL-3.0-only; GPL-3.0-or-later; SISSL;  SISSL-1.2; WTFPL\""
   },
   "dependencies": {
-    "@rdfjs/data-model": "1.2.0",
     "@types/rdf-js": "4.0.0"
   },
   "author": {
@@ -38,23 +37,24 @@
   "license": "MIT",
   "devDependencies": {
     "@rollup/plugin-commonjs": "^17.0.0",
-    "@rollup/plugin-node-resolve": "^11.0.0",
-    "@types/jest": "^26.0.0",
-    "@typescript-eslint/eslint-plugin": "^4.0.0",
-    "@typescript-eslint/parser": "^3.8.0",
-    "eslint": "^7.6.0",
+    "@rollup/plugin-node-resolve": "^11.0.1",
+    "@types/jest": "^26.0.19",
+    "@typescript-eslint/eslint-plugin": "^4.10.0",
+    "@typescript-eslint/parser": "^4.10.0",
+    "eslint": "^7.15.0",
     "eslint-plugin-import": "^2.20.2",
     "eslint-plugin-license-header": "^0.2.0",
-    "eslint-plugin-prettier": "^3.1.3",
-    "husky": "^4.2.5",
+    "eslint-plugin-prettier": "^3.3.0",
+    "husky": "^4.3.6",
     "jest": "^26.2.2",
     "license-checker": "^25.0.1",
-    "lint-staged": "^10.1.7",
+    "lint-staged": "^10.5.3",
     "prettier": "2.2.1",
-    "rollup": "^2.7.3",
+    "rdf-data-factory": "^1.0.4",
+    "rollup": "^2.35.1",
     "rollup-plugin-typescript2": "^0.29.0",
     "ts-jest": "^26.1.4",
-    "typescript": "^4.0.2"
+    "typescript": "^4.1.3"
   },
   "husky": {
     "hooks": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -17,7 +17,7 @@ export default {
     {
       dir: "umd",
       format: "umd",
-      name: "LitVocabTerm",
+      name: "VocabTerm",
     },
   ],
   plugins: [

--- a/src/VocabMultiLingualLiteral.test.ts
+++ b/src/VocabMultiLingualLiteral.test.ts
@@ -22,7 +22,8 @@
  * End license text.Source Distributions
  */
 
-import rdf from "@rdfjs/data-model";
+import { DataFactory } from "rdf-js";
+import { DataFactory as DataFactoryImpl } from "rdf-data-factory";
 
 import {
   VocabMultiLingualLiteral,
@@ -33,11 +34,12 @@ import {
 
 import expect from "expect";
 
-const TEST_IRI = rdf.namedNode(`test://iri#localName`);
+const rdfFactory: DataFactory = new DataFactoryImpl();
+const TEST_IRI = rdfFactory.namedNode(`test://iri#localName`);
 
 describe("The RDFJS Literal implementation", () => {
   it("should return the appropriate data type", () => {
-    const literal = new VocabMultiLingualLiteral(rdf, TEST_IRI);
+    const literal = new VocabMultiLingualLiteral(rdfFactory, TEST_IRI);
     literal.addValue("no language", NO_LANGUAGE_TAG);
     expect(literal.datatype.value).toBe(XSD_STRING);
     literal.addValue("whatever in Spanish", "es");
@@ -45,7 +47,7 @@ describe("The RDFJS Literal implementation", () => {
   });
 
   it("should return the value (if any)", () => {
-    const literal = new VocabMultiLingualLiteral(rdf, TEST_IRI);
+    const literal = new VocabMultiLingualLiteral(rdfFactory, TEST_IRI);
     expect(literal.value).toBe("");
     literal.addValue("no language", NO_LANGUAGE_TAG);
     expect(literal.value).toBe("no language");
@@ -54,7 +56,7 @@ describe("The RDFJS Literal implementation", () => {
   });
 
   it("should return the language (if any)", () => {
-    const literal = new VocabMultiLingualLiteral(rdf, TEST_IRI);
+    const literal = new VocabMultiLingualLiteral(rdfFactory, TEST_IRI);
     expect(literal.language).toBe("");
     literal.addValue("no language", NO_LANGUAGE_TAG);
     expect(literal.language).toBe("");
@@ -63,35 +65,41 @@ describe("The RDFJS Literal implementation", () => {
   });
 
   it("should be able to compare to other terms", () => {
-    const literal = new VocabMultiLingualLiteral(rdf, TEST_IRI);
+    const literal = new VocabMultiLingualLiteral(rdfFactory, TEST_IRI);
     literal.addValue("whatever no language", NO_LANGUAGE_TAG);
-    expect(literal.equals(rdf.literal("whatever no language", ""))).toBe(true);
+    expect(literal.equals(rdfFactory.literal("whatever no language", ""))).toBe(
+      true
+    );
     literal.addValue("whatever in Spanish", "es");
-    expect(literal.equals(rdf.literal("whatever in English", "en"))).toBe(
-      false
-    );
-    expect(literal.equals(rdf.literal("whatever in English", "es"))).toBe(
-      false
-    );
-    expect(literal.equals(rdf.literal("whatever in Spanish", "es"))).toBe(true);
+    expect(
+      literal.equals(rdfFactory.literal("whatever in English", "en"))
+    ).toBe(false);
+    expect(
+      literal.equals(rdfFactory.literal("whatever in English", "es"))
+    ).toBe(false);
+    expect(
+      literal.equals(rdfFactory.literal("whatever in Spanish", "es"))
+    ).toBe(true);
     expect(literal.equals(literal.datatype)).toBe(false);
   });
 });
 
 describe("Constructing a litteral", () => {
   it("should preserve the provided IRI", () => {
-    expect(new VocabMultiLingualLiteral(rdf, TEST_IRI).getIri()).toBe(TEST_IRI);
+    expect(new VocabMultiLingualLiteral(rdfFactory, TEST_IRI).getIri()).toBe(
+      TEST_IRI
+    );
   });
 
   it("should default to a default context message if none is provided", () => {
     const contextualLiteral = new VocabMultiLingualLiteral(
-      rdf,
+      rdfFactory,
       TEST_IRI,
       new Map<string, string>(),
       "Some contextual message"
     );
     const nonContextualLiteral = new VocabMultiLingualLiteral(
-      rdf,
+      rdfFactory,
       TEST_IRI,
       new Map<string, string>()
     );
@@ -102,7 +110,7 @@ describe("Constructing a litteral", () => {
 
 describe("Adding messages", () => {
   it("Should add message, no constructor values", () => {
-    const literal = new VocabMultiLingualLiteral(rdf, TEST_IRI);
+    const literal = new VocabMultiLingualLiteral(rdfFactory, TEST_IRI);
     literal
       .addValue("whatever in Spanish", "es")
       .addValue("whatever in Irish", "ga");
@@ -117,7 +125,7 @@ describe("Adding messages", () => {
 
   it("Should add message, including constructor values", () => {
     const literal = new VocabMultiLingualLiteral(
-      rdf,
+      rdfFactory,
       TEST_IRI,
       new Map([["en", "whatever"]])
     );
@@ -145,7 +153,7 @@ describe("Adding messages", () => {
 describe("Looking up messages", () => {
   it("Should return correct value, including with fallback", () => {
     const literal = new VocabMultiLingualLiteral(
-      rdf,
+      rdfFactory,
       TEST_IRI,
       new Map([
         ["en", "whatever"],
@@ -159,12 +167,12 @@ describe("Looking up messages", () => {
     );
 
     expect(literal.asLanguage("es").lookup(false)).toEqual(
-      rdf.literal("whatever", "en")
+      rdfFactory.literal("whatever", "en")
     );
   });
 
   it("Should default to English if no language", () => {
-    const literal = new VocabMultiLingualLiteral(rdf, TEST_IRI).addValue(
+    const literal = new VocabMultiLingualLiteral(rdfFactory, TEST_IRI).addValue(
       "whatever in English",
       "en"
     );
@@ -173,7 +181,7 @@ describe("Looking up messages", () => {
   });
 
   it("should default to a value without language if no other option is available", () => {
-    const literal = new VocabMultiLingualLiteral(rdf, TEST_IRI).addValue(
+    const literal = new VocabMultiLingualLiteral(rdfFactory, TEST_IRI).addValue(
       "This value has no language",
       NO_LANGUAGE_TAG
     );
@@ -184,13 +192,13 @@ describe("Looking up messages", () => {
   });
 
   it("Should return null if not mandatory and no values at all", () => {
-    const literal = new VocabMultiLingualLiteral(rdf, TEST_IRI);
+    const literal = new VocabMultiLingualLiteral(rdfFactory, TEST_IRI);
 
     expect(literal.asLanguage("es").lookup(false)).toBeUndefined();
   });
 
   it("Should return string with param markers", () => {
-    const literal = new VocabMultiLingualLiteral(rdf, TEST_IRI).addValue(
+    const literal = new VocabMultiLingualLiteral(rdfFactory, TEST_IRI).addValue(
       "whatever {{0}} in English {{1}}",
       "en"
     );
@@ -199,7 +207,7 @@ describe("Looking up messages", () => {
   });
 
   it("Should fail if remaining unexpanded param placeholders", () => {
-    const literal = new VocabMultiLingualLiteral(rdf, TEST_IRI).addValue(
+    const literal = new VocabMultiLingualLiteral(rdfFactory, TEST_IRI).addValue(
       "whatever {{0}} in English {{1}}",
       "en"
     );
@@ -212,13 +220,13 @@ describe("Looking up messages", () => {
   });
 
   it("Should lookup literal correctly", () => {
-    const literal = new VocabMultiLingualLiteral(rdf, TEST_IRI)
+    const literal = new VocabMultiLingualLiteral(rdfFactory, TEST_IRI)
       .addValue("whatever {{0}} in English", "en")
       .addValue("whatever {{1}} in Irish is backwards {{0}}", "ga");
 
     literal.asLanguage("ga");
     expect(literal.params(true, "example", "two")).toEqual(
-      rdf.literal("whatever two in Irish is backwards example", "ga")
+      rdfFactory.literal("whatever two in Irish is backwards example", "ga")
     );
 
     expect(literal.params(true, "example", "two")?.value).toBe(
@@ -226,17 +234,17 @@ describe("Looking up messages", () => {
     );
 
     expect(literal.setToEnglish.params(true, "example")).toEqual(
-      rdf.literal("whatever example in English", "en")
+      rdfFactory.literal("whatever example in English", "en")
     );
   });
 
   it("Should lookup with no params", () => {
-    const literal = new VocabMultiLingualLiteral(rdf, TEST_IRI)
+    const literal = new VocabMultiLingualLiteral(rdfFactory, TEST_IRI)
       .addValue("whatever in English", "en")
       .addValue("whatever in Irish", "ga");
 
     expect(literal.lookup(true)).toEqual(
-      rdf.literal("whatever in English", "en")
+      rdfFactory.literal("whatever in English", "en")
     );
 
     expect(literal.asLanguage("ga").lookup(true)?.value).toBe(
@@ -245,19 +253,19 @@ describe("Looking up messages", () => {
   });
 
   it("Should use English default if requested language not found", () => {
-    const literal = new VocabMultiLingualLiteral(rdf, TEST_IRI)
+    const literal = new VocabMultiLingualLiteral(rdfFactory, TEST_IRI)
       .addValue("whatever in English", "en")
       .addValue("whatever in Irish", "ga");
 
     // NOTE: our result will have an 'en' tag, even though we asked for 'fr'
     // (since we don't have a 'fr' message!).
     expect(literal.lookup(false)).toEqual(
-      rdf.literal("whatever in English", "en")
+      rdfFactory.literal("whatever in English", "en")
     );
   });
 
   it("Should throw with params if requested language not found", () => {
-    const literal = new VocabMultiLingualLiteral(rdf, TEST_IRI).addValue(
+    const literal = new VocabMultiLingualLiteral(rdfFactory, TEST_IRI).addValue(
       "whatever {{0}} in English",
       "en"
     );
@@ -270,7 +278,7 @@ describe("Looking up messages", () => {
   });
 
   it("Should return undefined if params requested language not found", () => {
-    const literal = new VocabMultiLingualLiteral(rdf, TEST_IRI);
+    const literal = new VocabMultiLingualLiteral(rdfFactory, TEST_IRI);
 
     expect(
       literal.asLanguage("fr").params(false, "use default")
@@ -278,22 +286,22 @@ describe("Looking up messages", () => {
   });
 
   it("Should return RDF literal using current language", () => {
-    const literal = new VocabMultiLingualLiteral(rdf, TEST_IRI)
+    const literal = new VocabMultiLingualLiteral(rdfFactory, TEST_IRI)
       .addValue("whatever {{0}} in English", "en")
       .addValue("whatever {{0}} in French", "fr");
 
     expect(literal.params(true, "use default")).toEqual(
-      rdf.literal("whatever use default in English", "en")
+      rdfFactory.literal("whatever use default in English", "en")
     );
 
     literal.asLanguage("fr");
     expect(literal.params(true, "La Vie!")).toEqual(
-      rdf.literal("whatever La Vie! in French", "fr")
+      rdfFactory.literal("whatever La Vie! in French", "fr")
     );
   });
 
   it("Should use language and params", () => {
-    const literal = new VocabMultiLingualLiteral(rdf, TEST_IRI)
+    const literal = new VocabMultiLingualLiteral(rdfFactory, TEST_IRI)
       .addValue("whatever {{0}} in English", "en")
       .addValue("whatever {{0}} in French", "fr");
 
@@ -309,7 +317,7 @@ describe("Looking up messages", () => {
 
 describe("Handling language tags", () => {
   it('should return an empty string for the "no language" tag', () => {
-    const literal = new VocabMultiLingualLiteral(rdf, TEST_IRI).addValue(
+    const literal = new VocabMultiLingualLiteral(rdfFactory, TEST_IRI).addValue(
       "value no language",
       NO_LANGUAGE_TAG
     );
@@ -317,7 +325,7 @@ describe("Handling language tags", () => {
   });
 
   it("should handle gracefully looking up an uninitialized literal", () => {
-    const literal = new VocabMultiLingualLiteral(rdf, TEST_IRI);
+    const literal = new VocabMultiLingualLiteral(rdfFactory, TEST_IRI);
     expect(
       literal.lookupButDefaultToEnglishOrNoLanguage(false)
     ).toBeUndefined();

--- a/src/VocabTerm.ts
+++ b/src/VocabTerm.ts
@@ -31,7 +31,6 @@ import {
 } from "./VocabMultiLingualLiteral";
 import { DataFactory, NamedNode, Term, Literal } from "rdf-js";
 import { IriString } from "./index";
-import rdf from "@rdfjs/data-model";
 
 const DEFAULT_LOCALE = "en";
 
@@ -411,22 +410,4 @@ class VocabTerm implements NamedNode {
   }
 }
 
-/**
- * This constructor exposes a base LitVocabTerm implementation by providing
- * a simple RDFJS Datafactory.
- * @param iri
- * @param context
- * @param strict
- */
-function buildBasicTerm(
-  iri: NamedNode | IriString,
-  context: Store,
-  strict?: boolean
-) {
-  if (typeof iri === "string") {
-    return new VocabTerm(rdf.namedNode(iri), rdf, context, strict);
-  }
-  return new VocabTerm(iri, rdf, context, strict);
-}
-
-export { VocabTerm, buildBasicTerm };
+export { VocabTerm };

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,7 @@ export {
   NO_LANGUAGE_TAG,
 } from "./VocabMultiLingualLiteral";
 
-export { VocabTerm, buildBasicTerm } from "./VocabTerm";
+export { VocabTerm } from "./VocabTerm";
 
 export { VocabTermRegistry } from "./VocabTermRegistry";
 


### PR DESCRIPTION
# New feature description
Replaced `@rdfjs/data-model` with `rdf-data-factory` (as it provides full TypeScript compatibility with the RDF/JS DataFactory type), and only require that as a Dev dependency as opposed to a full dependency.

# Checklist

- [X] All acceptance criteria are met.
- [X] Relevant documentation, if any, has been written/updated.
- [X] The changelog has been updated, if applicable.
- [X] New functions/types have been exported in `index.ts`, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
