### PR TITLE
Prevent dependabot from pushing to NPM

### DIFF
--- a/.github/workflows/cd-teardown.yml
+++ b/.github/workflows/cd-teardown.yml
@@ -7,7 +7,7 @@ env:
 jobs:
   unpublish-npm:
     runs-on: ubuntu-20.04
-    if: github.event.ref_type == 'branch'
+    if: ${{github.event.ref_type == 'branch' && github.actor != 'dependabot[bot]'}} 
     steps:
     - name: Prepare for unpublication from npm
       uses: actions/setup-node@v2.1.5

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -12,6 +12,7 @@ env:
 jobs:
   publish-npm:
     runs-on: ubuntu-20.04
+    if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
     - uses: actions/checkout@v2.3.4
     - name: Prepare for publication to npm


### PR DESCRIPTION
Dependabot doesn't have access to GH secrets, so it can't access NPM
token to publish there. This prevents dependabot PRs from running the
jobs that tries publishing to NPM.
