### PR TITLE
security: rotate npm credentials

### DIFF
--- a/.github/workflows/cd-teardown.yml
+++ b/.github/workflows/cd-teardown.yml
@@ -21,5 +21,5 @@ jobs:
     - name: Remove npm tag for the deleted branch
       run: npm dist-tag rm @inrupt/solid-common-vocab $TAG_SLUG
       env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        NODE_AUTH_TOKEN: ${{ secrets.INRUPT_NPM_TOKEN }}
     - run: echo "Package tag \`$TAG_SLUG\` unpublished."

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Publish an npm tag for this branch
       run: npm publish --access public --tag "$TAG_SLUG"
       env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        NODE_AUTH_TOKEN: ${{ secrets.INRUPT_NPM_TOKEN }}
     - run: |
         echo "Package published. To install, run:"
         echo ""

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,6 @@ jobs:
       run: |
         npm install
         npm test
-        npm publish --access public
+    - run: npm publish --access public
       env:
         NODE_AUTH_TOKEN: ${{ secrets.INRUPT_NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,4 +23,4 @@ jobs:
         npm test
         npm publish --access public
       env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        NODE_AUTH_TOKEN: ${{ secrets.INRUPT_NPM_TOKEN }}


### PR DESCRIPTION
This migrates us to a new secret managed by the GitHub Organisation for publishing to the inrupt npm organisation.