### PR TITLE
Enable code owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @inrupt/sdk-owners @inrupt/inrupt-professional-services


### PR DESCRIPTION
The ownership of this repository is shared between the JS team and profesional services.